### PR TITLE
Add Scrup compatible service

### DIFF
--- a/Resources/js/services/scrup.js
+++ b/Resources/js/services/scrup.js
@@ -1,0 +1,55 @@
+var request = require('request');
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+
+var ServiceSettings = require('../service-settings');
+
+function Service(main) {
+    this._settings = main.settings;
+    Service.super_.call(this);
+
+    this._name = "scrup";
+    this.name = "Scrup";
+    this.description = "Scrup compatible uploader";
+
+    this.settings = [
+        {
+            name: 'Upload URL',
+            key: 'upload_url',
+            type: 'text',
+            password: false,
+            default: '',
+            helpText: 'The URL to recieve the POST request'
+        }
+    ];
+
+    this.loadSettings();
+}
+
+util.inherits(Service, ServiceSettings);
+
+Service.prototype.upload = function(filepath, callback) {
+    var _self = this;
+
+    if (!_self.getSetting('upload_url')) return window.alert('No url configured for upload');
+
+    request.post({
+        url: _self.getSetting('upload_url'),
+        body: fs.readFileSync(filepath)
+    }, function(err, response, body) {
+        if (err) {
+            window.alert('error: ' + err);
+            return;
+        }
+
+        if (response.statusCode != 200) {
+            window.alert('error: server returned status code ' + response.statusCode);
+            return;
+        }
+
+        callback(body);
+    });
+}
+
+module.exports = Service;

--- a/Resources/js/services/scrup.js
+++ b/Resources/js/services/scrup.js
@@ -43,7 +43,7 @@ Service.prototype.upload = function(filepath, callback) {
             return;
         }
 
-        if (response.statusCode != 200) {
+        if (response.statusCode < 200 || response.statusCode >= 300) {
             window.alert('error: server returned status code ' + response.statusCode);
             return;
         }


### PR DESCRIPTION
[Scrup][0] is a reasonably popular application at $WORK, but isnt being
developed anymore. This adds a service compatible with how scrup works -
screenshot in the request body, and url retrieved from the remote
server rather than generated locally.

There's obviously some overlap with the http_post module. If that module
could get get the URL of the uploaded screenshot from the remote server
I'd have probably just re-worked my reciever to grok form data, but I
didnt want to fudge the preferences or adopt that behaviour implicitly
so I knocked this together quickly.

[0]: https://github.com/rsms/scrup